### PR TITLE
fix: delete local patch

### DIFF
--- a/keystore-worker/.cargo/config.toml
+++ b/keystore-worker/.cargo/config.toml
@@ -1,3 +1,0 @@
-# Local development: override git dependency with local path
-[patch.'https://github.com/out-layer/shared-tee-helpers']
-shared-tee-helpers = { path = "../../shared-tee-helpers" }


### PR DESCRIPTION
This is intended for local development only and it doesn't compile if the repo wasn't cloned before