### PR TITLE
Swap @near-wallet-selector for @hot-labs/near-connect

### DIFF
--- a/dashboard/contexts/NearWalletContext.tsx
+++ b/dashboard/contexts/NearWalletContext.tsx
@@ -1,13 +1,7 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { setupWalletSelector } from '@near-wallet-selector/core';
-import { setupMyNearWallet } from '@near-wallet-selector/my-near-wallet';
-import { setupMeteorWallet } from '@near-wallet-selector/meteor-wallet';
-import { setupHereWallet } from '@near-wallet-selector/here-wallet';
-import { setupIntearWallet } from '@near-wallet-selector/intear-wallet';
-import { setupModal } from '@near-wallet-selector/modal-ui';
-import '@near-wallet-selector/modal-ui/styles.css';
+import React, { createContext, useContext, useState, useEffect, useRef, useCallback, ReactNode } from 'react';
+import { NearConnector } from '@hot-labs/near-connect';
 
 export type NetworkType = 'testnet' | 'mainnet';
 
@@ -81,13 +75,12 @@ export function NearWalletProvider({ children }: { children: ReactNode }) {
     return (process.env.NEXT_PUBLIC_DEFAULT_NETWORK || 'testnet') as NetworkType;
   };
 
-  const [network] = useState<NetworkType>(getInitialNetwork);
+  const [network, setNetwork] = useState<NetworkType>(getInitialNetwork);
   const [accountId, setAccountId] = useState<string | null>(null);
-  const [selector, setSelector] = useState<any>(null);
-  const [modal, setModal] = useState<any>(null);
   const [isWalletReady, setIsWalletReady] = useState(false);
   const [shouldReopenModal, setShouldReopenModal] = useState(false);
 
+  const connectorRef = useRef<NearConnector | null>(null);
   const config = getNetworkConfig(network);
 
   // Check if we should reopen modal after page reload
@@ -107,139 +100,113 @@ export function NearWalletProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  // Initialize connector and restore session
   useEffect(() => {
-    // Mark as not ready when starting to setup
     setIsWalletReady(false);
-    setSelector(null);
-    setModal(null);
+    setAccountId(null);
 
-    setupWalletSelector({
-      network,
-      modules: [
-        setupMyNearWallet(),
-        setupMeteorWallet(),
-        setupHereWallet(),
-        setupIntearWallet(),
-      ],
-    }).then(async (_selector) => {
-      // Setup modal WITHOUT contractId to avoid function call access key creation
-      const _modal = setupModal(_selector, {
-        contractId: '', // Empty string means no contract-specific access key
-      });
+    const connector = new NearConnector({
+      network: network,
+      autoConnect: false,
+    });
 
-      // Subscribe to account changes to auto-update UI
-      const subscription = _selector.store.observable
-        .subscribe((state: { accounts: Array<{ accountId: string }> }) => {
-          const accounts = state.accounts;
-          if (accounts.length > 0) {
-            setAccountId(accounts[0].accountId);
-          } else {
-            setAccountId(null);
-          }
-        });
+    connectorRef.current = connector;
 
-      // Check if wallet is already connected
-      if (_selector.isSignedIn()) {
-        const accounts = await _selector.store.getState().accounts;
+    // Try to restore existing session
+    connector.getConnectedWallet()
+      .then(({ accounts }) => {
         if (accounts.length > 0) {
           setAccountId(accounts[0].accountId);
         }
-      }
-
-      // Set selector and modal AFTER everything is configured
-      setSelector(_selector);
-      setModal(_modal);
-
-      // Small delay to ensure modal is fully ready before allowing connections
-      setTimeout(() => {
+      })
+      .catch(() => {
+        // No existing session — that's fine
+      })
+      .finally(() => {
         setIsWalletReady(true);
-      }, 100);
+      });
 
-      // Cleanup subscription on unmount
-      return () => subscription.unsubscribe();
-    });
+    // Listen for sign-in events
+    const handleSignIn = ({ accounts }: { accounts: Array<{ accountId: string }> }) => {
+      if (accounts.length > 0) {
+        setAccountId(accounts[0].accountId);
+      }
+    };
+
+    const handleSignOut = () => {
+      setAccountId(null);
+    };
+
+    connector.on('wallet:signIn', handleSignIn as any);
+    connector.on('wallet:signOut', handleSignOut);
+
+    return () => {
+      connector.off('wallet:signIn', handleSignIn as any);
+      connector.off('wallet:signOut', handleSignOut);
+    };
   }, [network]);
 
-  const connect = () => {
-    if (modal) {
-      modal.show();
-    }
-  };
+  const connect = useCallback(() => {
+    if (!connectorRef.current) return;
+    connectorRef.current.connect().catch(() => {
+      // User rejected or wallet error — no action needed
+    });
+  }, []);
 
-  const disconnect = async () => {
-    if (selector) {
-      const wallet = await selector.wallet();
-      await wallet.signOut();
-      setAccountId(null);
+  const disconnect = useCallback(async () => {
+    if (!connectorRef.current) return;
+    try {
+      await connectorRef.current.disconnect();
+    } catch {
+      // Already disconnected
     }
-  };
+    setAccountId(null);
+  }, []);
 
-  const switchNetwork = async (newNetwork: NetworkType) => {
+  const switchNetwork = useCallback(async (newNetwork: NetworkType) => {
     // Store selected network in localStorage
     localStorage.setItem('near-wallet-selector:selectedNetworkId', newNetwork);
     // Set flag to reopen modal after reload
     localStorage.setItem('near-wallet-selector:reopenModal', 'true');
 
     // Disconnect current wallet before switching
-    if (selector && accountId) {
-      const wallet = await selector.wallet();
-      await wallet.signOut();
+    if (connectorRef.current && accountId) {
+      try {
+        await connectorRef.current.disconnect();
+      } catch {
+        // Already disconnected
+      }
       setAccountId(null);
     }
 
-    // Reload page to reinitialize wallet selector with new network
-    window.location.reload();
-  };
+    // Set new network — useEffect will reinitialize connector
+    setNetwork(newNetwork);
+  }, [accountId]);
 
-  const signAndSendTransaction = async (params: any) => {
-    if (!selector) throw new Error('Wallet not initialized');
-    const wallet = await selector.wallet();
+  const signAndSendTransaction = useCallback(async (params: any) => {
+    const connector = connectorRef.current;
+    if (!connector) throw new Error('Wallet not initialized');
+    const wallet = await connector.wallet();
     return await wallet.signAndSendTransaction(params);
-  };
+  }, []);
 
-  const signMessage = async (params: SignMessageParams): Promise<SignedMessage | null> => {
-    if (!selector || !accountId) throw new Error('Wallet not connected');
-
-    const wallet = await selector.wallet();
-
-    // Check if wallet supports signMessage (NEP-413)
-    if (!wallet.signMessage) {
-      throw new Error('Current wallet does not support message signing. Please use a wallet that supports NEP-413 (e.g., MyNearWallet, Meteor, Here Wallet)');
-    }
+  const signMessage = useCallback(async (params: SignMessageParams): Promise<SignedMessage | null> => {
+    const connector = connectorRef.current;
+    if (!connector || !accountId) throw new Error('Wallet not connected');
 
     try {
+      const wallet = await connector.wallet();
+
       const result = await wallet.signMessage({
         message: params.message,
         recipient: params.recipient,
         nonce: Buffer.from(params.nonce, 'base64'),
-      });
-
-      if (!result) {
-        return null;
-      }
-
-      // Handle signature format - it can be Uint8Array or base64 string depending on wallet
-      let signatureBase64: string;
-      if (result.signature instanceof Uint8Array) {
-        signatureBase64 = Buffer.from(result.signature).toString('base64');
-      } else if (typeof result.signature === 'string') {
-        // Already a string - assume it's base64
-        signatureBase64 = result.signature;
-      } else {
-        // Array-like object
-        signatureBase64 = Buffer.from(result.signature as ArrayLike<number>).toString('base64');
-      }
-
-      console.log('signMessage result:', {
-        signatureType: typeof result.signature,
-        signatureIsUint8Array: result.signature instanceof Uint8Array,
-        signatureLength: result.signature?.length,
-        signatureBase64Length: signatureBase64.length,
-        publicKey: result.publicKey,
+        network: network,
+        signerId: accountId,
       });
 
       return {
-        signature: signatureBase64,
+        signature: result.signature,
         publicKey: result.publicKey,
         accountId: result.accountId,
       };
@@ -247,12 +214,9 @@ export function NearWalletProvider({ children }: { children: ReactNode }) {
       console.error('Error signing message:', error);
       throw error;
     }
-  };
+  }, [accountId, network]);
 
-  const viewMethod = async (params: { contractId: string; method: string; args?: Record<string, unknown> }) => {
-    if (!selector) throw new Error('Wallet not initialized');
-
-    // Use selector's network to make view call via RPC
+  const viewMethod = useCallback(async (params: { contractId: string; method: string; args?: Record<string, unknown> }) => {
     const response = await fetch(config.rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -283,7 +247,7 @@ export function NearWalletProvider({ children }: { children: ReactNode }) {
 
     const resultStr = new TextDecoder().decode(new Uint8Array(resultBytes));
     return JSON.parse(resultStr);
-  };
+  }, [config.rpcUrl]);
 
   return (
     <NearWalletContext.Provider

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,13 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@hot-labs/near-connect": "latest",
+    "@near-js/types": "latest",
     "@near-js/transactions": "^2.3.3",
-    "@near-wallet-selector/core": "^10.0.0",
-    "@near-wallet-selector/here-wallet": "^10.1.0",
-    "@near-wallet-selector/intear-wallet": "^10.1.0",
-    "@near-wallet-selector/meteor-wallet": "^10.1.0",
-    "@near-wallet-selector/modal-ui": "^10.0.0",
-    "@near-wallet-selector/my-near-wallet": "^10.0.0",
     "@stablelib/chacha20poly1305": "^2.0.1",
     "@stablelib/hkdf": "^2.0.1",
     "@stablelib/random": "^2.0.1",


### PR DESCRIPTION
why? i cant use the app on my phone :(  i want to login to to "approve my agent perm bun unable"
anyway  it just show its possible and not much work
interation with onchain are preserve (this is me deleting  a project) 
https://near.rocks/tx/Er18YMiQdB9opFLQ4tmktV29ew2E49a3i3pRJ1htNh95
## Summary

Replace 6 `@near-wallet-selector/*` packages with a single `@hot-labs/near-connect` dependency in the dashboard.

## What changed

**2 files, -40 lines net:**

- **`dashboard/contexts/NearWalletContext.tsx`** — Rewrote internals using `NearConnector`. The exported `useNearWallet()` hook returns the identical interface — all 15+ consumer files (WalletConnectionModal, NetworkSwitcher, Settings, Projects, Secrets, WalletApprovals, Earnings, PaymentKeys, etc.) require zero modifications.

  | Before (wallet-selector) | After (near-connect) |
  |---|---|
  | `setupWalletSelector()` + `setupModal()` | `new NearConnector({ network })` |
  | `modal.show()` | `connector.connect()` (built-in wallet picker popup) |
  | `selector.store.observable.subscribe()` | `connector.on('wallet:signIn', ...)` |
  | `switchNetwork` → `window.location.reload()` | `switchNetwork` → `setNetwork()` (no page reload) |
  | `signMessage` — handle Uint8Array \| string \| ArrayLike | `signMessage` — always returns `string` |
  | 6 wallet modules + modal-ui CSS import | 1 import, zero CSS |

- **`dashboard/package.json`** — Removed 6 `@near-wallet-selector/*` packages, added `@hot-labs/near-connect` + `@near-js/types`.

## Why

- **Zero dependencies** — near-connect is zero-dep, sandboxed wallet connector. wallet-selector pulls in 6+ packages with transitive deps.
- **Sandboxed wallet code** — each wallet runs in its own sandbox, reducing supply-chain risk.
- **No page reload on network switch** — near-connect reinitializes cleanly via React state, no `window.location.reload()`.
- **Built-in wallet picker** — near-connect ships its own popup UI, no separate modal-ui package needed.
- **Easier wallet updates** — wallet manifests are loaded from a CDN, new wallets appear without a package update.

## Verification

- `next build --turbopack` passes clean, all 30+ routes compile
- Dev server runs on localhost:3002, wallet context initializes without errors
- npm install: 437 packages (reduced from wallet-selector's transitive tree)