### PR TITLE
fix: add Authorization header to encrypt-policy call

### DIFF
--- a/dashboard/lib/wallet-policy.ts
+++ b/dashboard/lib/wallet-policy.ts
@@ -234,7 +234,7 @@ export async function submitPolicy(params: SubmitPolicyParams): Promise<SubmitPo
   // Step 1: Encrypt policy via coordinator
   const encryptResp = await fetch(`${coordinatorUrl}/wallet/v1/encrypt-policy`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
     body: JSON.stringify({ wallet_id: walletId, ...policyData }),
   });
 


### PR DESCRIPTION
## Bug

`/wallet/v1/encrypt-policy` was missing the `Authorization: Bearer <api_key>` header, causing `missing_auth` errors when setting wallet policies.

## Fix

Added `Authorization: \`Bearer ${apiKey}\`` header to the `encrypt-policy` fetch call in `dashboard/lib/wallet-policy.ts` (line 237).

## Reproduction

```bash
curl -s -X POST https://api.outlayer.fastnear.com/wallet/v1/encrypt-policy \
  -H "Content-Type: application/json" \
  -d '{"wallet_id":"test"}'
# Returns: {"error":"missing_auth","message":"Provide Authorization: Bearer <api_key> header. Register at POST /register"}
```