### PR TITLE
feat: add http-get and http-post to near:rpc/api

### DIFF
--- a/worker/src/executor/mod.rs
+++ b/worker/src/executor/mod.rs
@@ -42,7 +42,7 @@ use crate::outlayer_rpc::RpcProxy;
 use crate::outlayer_storage::client::StorageConfig;
 
 mod wasi_p1;
-mod wasi_p2;
+pub(crate) mod wasi_p2;
 
 /// VRF configuration for host functions
 #[derive(Clone)]

--- a/worker/src/executor/wasi_p2.rs
+++ b/worker/src/executor/wasi_p2.rs
@@ -109,7 +109,7 @@ impl WasiView for HostState {
 
 /// True for addresses a sandboxed guest must not reach: loopback, RFC1918
 /// private, link-local (incl. cloud metadata 169.254.169.254), CGNAT, ULA, etc.
-fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
+pub(crate) fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
     use std::net::IpAddr;
     match ip {
         IpAddr::V4(v4) => {

--- a/worker/src/outlayer_rpc/host_functions_sync.rs
+++ b/worker/src/outlayer_rpc/host_functions_sync.rs
@@ -33,9 +33,6 @@ wasmtime::component::bindgen!({
     world: "rpc-host",
 });
 
-/// Maximum HTTP response body size (1 MB) - prevents OOM from large responses
-const MAX_HTTP_RESPONSE_BYTES: usize = 1024 * 1024;
-
 /// RPC Proxy client with rate limiting (using blocking HTTP)
 pub struct RpcProxy {
     /// HTTP client for RPC requests (blocking)
@@ -178,8 +175,8 @@ impl RpcProxy {
     }
 
     /// HTTP GET request (blocking, with SSRF protection)
-    /// Returns body on success, errors via anyhow (same pattern as call_method)
-    pub fn http_get(&self, url: &str, headers_json: Option<&str>) -> Result<String> {
+    /// Parses response as JSON, returns Value (same as call_method)
+    pub fn http_get(&self, url: &str, headers_json: Option<&str>) -> Result<Value> {
         self.check_rate_limit()?;
         self.validate_url(url)?;
 
@@ -199,16 +196,13 @@ impl RpcProxy {
         }
 
         let body = response.text().context("Failed to read HTTP response body")?;
-        if body.len() > MAX_HTTP_RESPONSE_BYTES {
-            anyhow::bail!("HTTP response too large: {} bytes (max {})", body.len(), MAX_HTTP_RESPONSE_BYTES);
-        }
-        Ok(body)
+        serde_json::from_str(&body).context("HTTP GET response is not valid JSON")
     }
 
     /// HTTP POST request (blocking, with SSRF protection)
-    /// Returns body on success, errors via anyhow (same pattern as call_method)
+    /// Parses response as JSON, returns Value (same as call_method)
     /// Content-Type defaults to application/json; override via headers if needed.
-    pub fn http_post(&self, url: &str, body: &str, headers_json: Option<&str>) -> Result<String> {
+    pub fn http_post(&self, url: &str, body: &str, headers_json: Option<&str>) -> Result<Value> {
         self.check_rate_limit()?;
         self.validate_url(url)?;
 
@@ -234,10 +228,7 @@ impl RpcProxy {
         }
 
         let response_body = response.text().context("Failed to read HTTP response body")?;
-        if response_body.len() > MAX_HTTP_RESPONSE_BYTES {
-            anyhow::bail!("HTTP response too large: {} bytes (max {})", response_body.len(), MAX_HTTP_RESPONSE_BYTES);
-        }
-        Ok(response_body)
+        serde_json::from_str(&response_body).context("HTTP POST response is not valid JSON")
     }
 
     /// SSRF protection: validate URL and resolve DNS to block internal IPs
@@ -911,14 +902,14 @@ impl near::rpc::api::Host for RpcHostState {
 
     fn http_get(&mut self, url: String, headers: Option<String>) -> (String, String) {
         match self.proxy.http_get(&url, headers.as_deref()) {
-            Ok(body) => (body, String::new()),
+            Ok(result) => (serde_json::to_string(&result).unwrap_or_default(), String::new()),
             Err(e) => (String::new(), e.to_string()),
         }
     }
 
     fn http_post(&mut self, url: String, body: String, headers: Option<String>) -> (String, String) {
         match self.proxy.http_post(&url, &body, headers.as_deref()) {
-            Ok(response) => (response, String::new()),
+            Ok(result) => (serde_json::to_string(&result).unwrap_or_default(), String::new()),
             Err(e) => (String::new(), e.to_string()),
         }
     }

--- a/worker/src/outlayer_rpc/host_functions_sync.rs
+++ b/worker/src/outlayer_rpc/host_functions_sync.rs
@@ -178,13 +178,13 @@ impl RpcProxy {
     }
 
     /// HTTP GET request (blocking, with SSRF protection)
-    /// Returns (body, error) tuple - error is empty string on success
-    pub fn http_get(&self, url: &str, headers_json: Option<&str>) -> Result<(String, String)> {
+    /// Returns body on success, errors via anyhow (same pattern as call_method)
+    pub fn http_get(&self, url: &str, headers_json: Option<&str>) -> Result<String> {
         self.check_rate_limit()?;
         self.validate_url(url)?;
 
         let headers = Self::parse_headers_json(headers_json);
-        info!("[HTTP] GET {}", Self::safe_url_display(url));
+        info!("[RPC] HTTP GET {}", Self::safe_url_display(url));
 
         let mut req = self.client.get(url);
         for (name, value) in headers {
@@ -195,40 +195,30 @@ impl RpcProxy {
         let status = response.status();
         if !status.is_success() {
             let error_text = response.text().unwrap_or_default();
-            return Ok((String::new(), format!("HTTP {}: {}", status, error_text)));
+            anyhow::bail!("HTTP GET {}: {}", status, error_text);
         }
 
         let body = response.text().context("Failed to read HTTP response body")?;
         if body.len() > MAX_HTTP_RESPONSE_BYTES {
-            return Ok((String::new(), format!("HTTP response too large: {} bytes (max {})", body.len(), MAX_HTTP_RESPONSE_BYTES)));
+            anyhow::bail!("HTTP response too large: {} bytes (max {})", body.len(), MAX_HTTP_RESPONSE_BYTES);
         }
-        Ok((body, String::new()))
+        Ok(body)
     }
 
     /// HTTP POST request (blocking, with SSRF protection)
-    /// Returns (body, error) tuple - error is empty string on success
-    pub fn http_post(
-        &self,
-        url: &str,
-        body: &str,
-        content_type: &str,
-        headers_json: Option<&str>,
-    ) -> Result<(String, String)> {
+    /// Returns body on success, errors via anyhow (same pattern as call_method)
+    /// Content-Type defaults to application/json; override via headers if needed.
+    pub fn http_post(&self, url: &str, body: &str, headers_json: Option<&str>) -> Result<String> {
         self.check_rate_limit()?;
         self.validate_url(url)?;
 
         let headers = Self::parse_headers_json(headers_json);
-        info!(
-            "[HTTP] POST {} ({} bytes, {})",
-            Self::safe_url_display(url),
-            body.len(),
-            content_type
-        );
+        info!("[RPC] HTTP POST {} ({} bytes)", Self::safe_url_display(url), body.len());
 
         let mut req = self
             .client
             .post(url)
-            .header("Content-Type", content_type);
+            .header("Content-Type", "application/json");
         for (name, value) in headers {
             req = req.header(name, value);
         }
@@ -240,14 +230,14 @@ impl RpcProxy {
         let status = response.status();
         if !status.is_success() {
             let error_text = response.text().unwrap_or_default();
-            return Ok((String::new(), format!("HTTP {}: {}", status, error_text)));
+            anyhow::bail!("HTTP POST {}: {}", status, error_text);
         }
 
         let response_body = response.text().context("Failed to read HTTP response body")?;
         if response_body.len() > MAX_HTTP_RESPONSE_BYTES {
-            return Ok((String::new(), format!("HTTP response too large: {} bytes (max {})", response_body.len(), MAX_HTTP_RESPONSE_BYTES)));
+            anyhow::bail!("HTTP response too large: {} bytes (max {})", response_body.len(), MAX_HTTP_RESPONSE_BYTES);
         }
-        Ok((response_body, String::new()))
+        Ok(response_body)
     }
 
     /// SSRF protection: validate URL and resolve DNS to block internal IPs
@@ -921,21 +911,14 @@ impl near::rpc::api::Host for RpcHostState {
 
     fn http_get(&mut self, url: String, headers: Option<String>) -> (String, String) {
         match self.proxy.http_get(&url, headers.as_deref()) {
-            Ok((body, error)) if error.is_empty() => (body, String::new()),
-            Ok((_, error)) => (String::new(), error),
+            Ok(body) => (body, String::new()),
             Err(e) => (String::new(), e.to_string()),
         }
     }
 
-    fn http_post(&mut self, url: String, body: String, content_type: String, headers: Option<String>) -> (String, String) {
-        let ct = if content_type.is_empty() {
-            "application/json"
-        } else {
-            &content_type
-        };
-        match self.proxy.http_post(&url, &body, ct, headers.as_deref()) {
-            Ok((response, error)) if error.is_empty() => (response, String::new()),
-            Ok((_, error)) => (String::new(), error),
+    fn http_post(&mut self, url: String, body: String, headers: Option<String>) -> (String, String) {
+        match self.proxy.http_post(&url, &body, headers.as_deref()) {
+            Ok(response) => (response, String::new()),
             Err(e) => (String::new(), e.to_string()),
         }
     }

--- a/worker/src/outlayer_rpc/host_functions_sync.rs
+++ b/worker/src/outlayer_rpc/host_functions_sync.rs
@@ -151,19 +151,46 @@ impl RpcProxy {
         Ok(body)
     }
 
+    /// Parse a JSON object string like `{"Authorization": "Bearer x", "Accept": "text/plain"}`
+    /// into a list of (name, value) header pairs. Returns empty vec on parse failure (non-fatal).
+    fn parse_headers_json(headers_json: Option<&str>) -> Vec<(String, String)> {
+        let Some(json_str) = headers_json else {
+            return vec![];
+        };
+        let Ok(val) = serde_json::from_str::<Value>(json_str) else {
+            return vec![];
+        };
+        let Some(obj) = val.as_object() else {
+            return vec![];
+        };
+        let mut headers = vec![];
+        for (key, v) in obj {
+            if let Some(s) = v.as_str() {
+                // Validate that the header name is valid HTTP
+                if reqwest::header::HeaderName::from_bytes(key.as_bytes()).is_ok() {
+                    if reqwest::header::HeaderValue::from_str(s).is_ok() {
+                        headers.push((key.clone(), s.to_string()));
+                    }
+                }
+            }
+        }
+        headers
+    }
+
     /// HTTP GET request (blocking, with SSRF protection)
     /// Returns (body, error) tuple - error is empty string on success
-    pub fn http_get(&self, url: &str) -> Result<(String, String)> {
+    pub fn http_get(&self, url: &str, headers_json: Option<&str>) -> Result<(String, String)> {
         self.check_rate_limit()?;
         self.validate_url(url)?;
 
+        let headers = Self::parse_headers_json(headers_json);
         info!("[HTTP] GET {}", Self::safe_url_display(url));
 
-        let response = self
-            .client
-            .get(url)
-            .send()
-            .context("Failed to send HTTP GET request")?;
+        let mut req = self.client.get(url);
+        for (name, value) in headers {
+            req = req.header(name, value);
+        }
+        let response = req.send().context("Failed to send HTTP GET request")?;
 
         let status = response.status();
         if !status.is_success() {
@@ -180,16 +207,32 @@ impl RpcProxy {
 
     /// HTTP POST request (blocking, with SSRF protection)
     /// Returns (body, error) tuple - error is empty string on success
-    pub fn http_post(&self, url: &str, body: &str, content_type: &str) -> Result<(String, String)> {
+    pub fn http_post(
+        &self,
+        url: &str,
+        body: &str,
+        content_type: &str,
+        headers_json: Option<&str>,
+    ) -> Result<(String, String)> {
         self.check_rate_limit()?;
         self.validate_url(url)?;
 
-        info!("[HTTP] POST {} ({} bytes, {})", Self::safe_url_display(url), body.len(), content_type);
+        let headers = Self::parse_headers_json(headers_json);
+        info!(
+            "[HTTP] POST {} ({} bytes, {})",
+            Self::safe_url_display(url),
+            body.len(),
+            content_type
+        );
 
-        let response = self
+        let mut req = self
             .client
             .post(url)
-            .header("Content-Type", content_type)
+            .header("Content-Type", content_type);
+        for (name, value) in headers {
+            req = req.header(name, value);
+        }
+        let response = req
             .body(body.to_string())
             .send()
             .context("Failed to send HTTP POST request")?;
@@ -876,21 +919,21 @@ impl near::rpc::api::Host for RpcHostState {
 
     // ==================== HTTP API ====================
 
-    fn http_get(&mut self, url: String) -> (String, String) {
-        match self.proxy.http_get(&url) {
+    fn http_get(&mut self, url: String, headers: Option<String>) -> (String, String) {
+        match self.proxy.http_get(&url, headers.as_deref()) {
             Ok((body, error)) if error.is_empty() => (body, String::new()),
             Ok((_, error)) => (String::new(), error),
             Err(e) => (String::new(), e.to_string()),
         }
     }
 
-    fn http_post(&mut self, url: String, body: String, content_type: String) -> (String, String) {
+    fn http_post(&mut self, url: String, body: String, content_type: String, headers: Option<String>) -> (String, String) {
         let ct = if content_type.is_empty() {
             "application/json"
         } else {
             &content_type
         };
-        match self.proxy.http_post(&url, &body, ct) {
+        match self.proxy.http_post(&url, &body, ct, headers.as_deref()) {
             Ok((response, error)) if error.is_empty() => (response, String::new()),
             Ok((_, error)) => (String::new(), error),
             Err(e) => (String::new(), e.to_string()),

--- a/worker/src/outlayer_rpc/host_functions_sync.rs
+++ b/worker/src/outlayer_rpc/host_functions_sync.rs
@@ -164,10 +164,10 @@ impl RpcProxy {
         for (key, v) in obj {
             if let Some(s) = v.as_str() {
                 // Validate that the header name is valid HTTP
-                if reqwest::header::HeaderName::from_bytes(key.as_bytes()).is_ok() {
-                    if reqwest::header::HeaderValue::from_str(s).is_ok() {
-                        headers.push((key.clone(), s.to_string()));
-                    }
+                if reqwest::header::HeaderName::from_bytes(key.as_bytes()).is_ok()
+                    && reqwest::header::HeaderValue::from_str(s).is_ok()
+                {
+                    headers.push((key.clone(), s.to_string()));
                 }
             }
         }

--- a/worker/src/outlayer_rpc/host_functions_sync.rs
+++ b/worker/src/outlayer_rpc/host_functions_sync.rs
@@ -25,11 +25,16 @@ use std::sync::Arc;
 use std::time::Duration;
 use wasmtime::component::Linker;
 
+use crate::executor::wasi_p2::is_blocked_ip;
+
 // Generate bindings from WIT - sync mode for simpler implementation
 wasmtime::component::bindgen!({
     path: "wit",
     world: "rpc-host",
 });
+
+/// Maximum HTTP response body size (1 MB) - prevents OOM from large responses
+const MAX_HTTP_RESPONSE_BYTES: usize = 1024 * 1024;
 
 /// RPC Proxy client with rate limiting (using blocking HTTP)
 pub struct RpcProxy {
@@ -130,7 +135,6 @@ impl RpcProxy {
         let response = self
             .client
             .post(&self.rpc_url)
-            .header("Content-Type", "application/json")
             .json(&request)
             .send()
             .context("Failed to send RPC request")?;
@@ -145,6 +149,108 @@ impl RpcProxy {
             .json()
             .context("Failed to parse RPC response")?;
         Ok(body)
+    }
+
+    /// HTTP GET request (blocking, with SSRF protection)
+    /// Returns (body, error) tuple - error is empty string on success
+    pub fn http_get(&self, url: &str) -> Result<(String, String)> {
+        self.check_rate_limit()?;
+        self.validate_url(url)?;
+
+        info!("[HTTP] GET {}", Self::safe_url_display(url));
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .context("Failed to send HTTP GET request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().unwrap_or_default();
+            return Ok((String::new(), format!("HTTP {}: {}", status, error_text)));
+        }
+
+        let body = response.text().context("Failed to read HTTP response body")?;
+        if body.len() > MAX_HTTP_RESPONSE_BYTES {
+            return Ok((String::new(), format!("HTTP response too large: {} bytes (max {})", body.len(), MAX_HTTP_RESPONSE_BYTES)));
+        }
+        Ok((body, String::new()))
+    }
+
+    /// HTTP POST request (blocking, with SSRF protection)
+    /// Returns (body, error) tuple - error is empty string on success
+    pub fn http_post(&self, url: &str, body: &str, content_type: &str) -> Result<(String, String)> {
+        self.check_rate_limit()?;
+        self.validate_url(url)?;
+
+        info!("[HTTP] POST {} ({} bytes, {})", Self::safe_url_display(url), body.len(), content_type);
+
+        let response = self
+            .client
+            .post(url)
+            .header("Content-Type", content_type)
+            .body(body.to_string())
+            .send()
+            .context("Failed to send HTTP POST request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().unwrap_or_default();
+            return Ok((String::new(), format!("HTTP {}: {}", status, error_text)));
+        }
+
+        let response_body = response.text().context("Failed to read HTTP response body")?;
+        if response_body.len() > MAX_HTTP_RESPONSE_BYTES {
+            return Ok((String::new(), format!("HTTP response too large: {} bytes (max {})", response_body.len(), MAX_HTTP_RESPONSE_BYTES)));
+        }
+        Ok((response_body, String::new()))
+    }
+
+    /// SSRF protection: validate URL and resolve DNS to block internal IPs
+    fn validate_url(&self, url: &str) -> Result<()> {
+        let parsed = reqwest::Url::parse(url)
+            .with_context(|| format!("Invalid URL: {}", url))?;
+
+        // Check scheme
+        match parsed.scheme() {
+            "https" | "http" => {}
+            scheme => anyhow::bail!("Unsupported URL scheme: {}. Only http and https allowed.", scheme),
+        }
+
+        // Extract host
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("URL has no host"))?;
+
+        // Determine port
+        let port = parsed.port().unwrap_or(match parsed.scheme() {
+            "https" => 443,
+            "http" => 80,
+            _ => 80,
+        });
+
+        // DNS lookup with SSRF protection
+        let addrs: Vec<std::net::SocketAddr> = std::net::ToSocketAddrs::to_socket_addrs(&(host, port))
+            .with_context(|| format!("DNS resolution failed for {}:{}", host, port))?
+            .collect();
+
+        if addrs.is_empty() {
+            anyhow::bail!("DNS resolution returned no addresses for {}:{}", host, port);
+        }
+
+        // Block internal/private IPs
+        for addr in &addrs {
+            if is_blocked_ip(addr.ip()) {
+                anyhow::bail!(
+                    "Blocked SSRF attempt: {} resolves to internal/private address {}",
+                    Self::safe_url_display(url),
+                    addr.ip()
+                );
+            }
+        }
+
+        Ok(())
     }
 
     #[allow(dead_code)]
@@ -764,6 +870,29 @@ impl near::rpc::api::Host for RpcHostState {
 
         match self.proxy.call_method(&method, params) {
             Ok(result) => (serde_json::to_string(&result).unwrap_or_default(), String::new()),
+            Err(e) => (String::new(), e.to_string()),
+        }
+    }
+
+    // ==================== HTTP API ====================
+
+    fn http_get(&mut self, url: String) -> (String, String) {
+        match self.proxy.http_get(&url) {
+            Ok((body, error)) if error.is_empty() => (body, String::new()),
+            Ok((_, error)) => (String::new(), error),
+            Err(e) => (String::new(), e.to_string()),
+        }
+    }
+
+    fn http_post(&mut self, url: String, body: String, content_type: String) -> (String, String) {
+        let ct = if content_type.is_empty() {
+            "application/json"
+        } else {
+            &content_type
+        };
+        match self.proxy.http_post(&url, &body, ct) {
+            Ok((response, error)) if error.is_empty() => (response, String::new()),
+            Ok((_, error)) => (String::new(), error),
             Err(e) => (String::new(), e.to_string()),
         }
     }

--- a/worker/src/outlayer_rpc/host_functions_sync.rs
+++ b/worker/src/outlayer_rpc/host_functions_sync.rs
@@ -97,6 +97,23 @@ impl RpcProxy {
         Ok(())
     }
 
+    /// Rewrite URL host to a resolved IP address (prevents DNS rebinding).
+    /// Keeps original Host header intact via reqwest's default behavior.
+    fn pin_url_to_addr(url: &str, addr: std::net::SocketAddr) -> String {
+        let parsed = reqwest::Url::parse(url).unwrap_or_else(|_| reqwest::Url::parse("http://0.0.0.0").unwrap());
+        let scheme = parsed.scheme();
+        let path = parsed.path();
+        let query = parsed.query().map(|q| format!("?{}", q)).unwrap_or_default();
+
+        // Build URL with IP address, preserving original port
+        let ip_port = if (scheme == "http" && addr.port() == 80) || (scheme == "https" && addr.port() == 443) {
+            format!("{}://{}{}", scheme, addr.ip(), path)
+        } else {
+            format!("{}://{}:{}{}", scheme, addr.ip(), addr.port(), path)
+        };
+        format!("{}{}", ip_port, query)
+    }
+
     /// Safe display of URL - hides API keys and query parameters
     fn safe_url_display(url: &str) -> String {
         if let Some(question_mark_pos) = url.find('?') {
@@ -178,12 +195,15 @@ impl RpcProxy {
     /// Parses response as JSON, returns Value (same as call_method)
     pub fn http_get(&self, url: &str, headers_json: Option<&str>) -> Result<Value> {
         self.check_rate_limit()?;
-        self.validate_url(url)?;
+        let validated_addr = self.validate_url(url)?;
 
         let headers = Self::parse_headers_json(headers_json);
-        info!("[RPC] HTTP GET {}", Self::safe_url_display(url));
 
-        let mut req = self.client.get(url);
+        // Pin to resolved IP to prevent DNS rebinding (host header preserved)
+        let pinned_url = Self::pin_url_to_addr(url, validated_addr);
+        info!("[RPC] HTTP GET {} (pinned to {})", Self::safe_url_display(url), validated_addr);
+
+        let mut req = self.client.get(&pinned_url);
         for (name, value) in headers {
             req = req.header(name, value);
         }
@@ -204,15 +224,22 @@ impl RpcProxy {
     /// Content-Type defaults to application/json; override via headers if needed.
     pub fn http_post(&self, url: &str, body: &str, headers_json: Option<&str>) -> Result<Value> {
         self.check_rate_limit()?;
-        self.validate_url(url)?;
+        let validated_addr = self.validate_url(url)?;
 
         let headers = Self::parse_headers_json(headers_json);
-        info!("[RPC] HTTP POST {} ({} bytes)", Self::safe_url_display(url), body.len());
+
+        // Pin to resolved IP to prevent DNS rebinding (host header preserved)
+        let pinned_url = Self::pin_url_to_addr(url, validated_addr);
+        info!("[RPC] HTTP POST {} ({} bytes, pinned to {})", Self::safe_url_display(url), body.len(), validated_addr);
 
         let mut req = self
             .client
-            .post(url)
-            .header("Content-Type", "application/json");
+            .post(&pinned_url);
+        // Set default Content-Type only if user didn't override it
+        let has_content_type = headers.iter().any(|(n, _)| n.eq_ignore_ascii_case("content-type"));
+        if !has_content_type {
+            req = req.header("Content-Type", "application/json");
+        }
         for (name, value) in headers {
             req = req.header(name, value);
         }
@@ -232,7 +259,7 @@ impl RpcProxy {
     }
 
     /// SSRF protection: validate URL and resolve DNS to block internal IPs
-    fn validate_url(&self, url: &str) -> Result<()> {
+    fn validate_url(&self, url: &str) -> Result<std::net::SocketAddr> {
         let parsed = reqwest::Url::parse(url)
             .with_context(|| format!("Invalid URL: {}", url))?;
 
@@ -263,7 +290,7 @@ impl RpcProxy {
             anyhow::bail!("DNS resolution returned no addresses for {}:{}", host, port);
         }
 
-        // Block internal/private IPs
+        // Return first non-blocked addr
         for addr in &addrs {
             if is_blocked_ip(addr.ip()) {
                 anyhow::bail!(
@@ -272,9 +299,10 @@ impl RpcProxy {
                     addr.ip()
                 );
             }
+            return Ok(*addr);
         }
 
-        Ok(())
+        unreachable!("addrs is non-empty but no addr passed the IP check")
     }
 
     #[allow(dead_code)]

--- a/worker/wit/world.wit
+++ b/worker/wit/world.wit
@@ -102,10 +102,11 @@ interface api {
     /// headers: optional JSON object of extra headers, e.g. {"Authorization": "Bearer ...", "Accept": "application/json"}
     http-get: func(url: string, headers: option<string>) -> tuple<string, string>;
 
-    /// HTTP POST request with body, content-type, and optional headers (blocking, with SSRF protection)
+    /// HTTP POST request with body and optional headers (blocking, with SSRF protection)
     /// Returns (body, error) - error is empty string on success
+    /// Content-Type defaults to application/json; override via headers if needed
     /// headers: optional JSON object of extra headers, e.g. {"Authorization": "Bearer ..."}
-    http-post: func(url: string, body: string, content-type: string, headers: option<string>) -> tuple<string, string>;
+    http-post: func(url: string, body: string, headers: option<string>) -> tuple<string, string>;
 }
 
 world rpc-host {

--- a/worker/wit/world.wit
+++ b/worker/wit/world.wit
@@ -99,11 +99,13 @@ interface api {
     /// HTTP GET request (blocking, with SSRF protection)
     /// Returns (body, error) - error is empty string on success
     /// Security: DNS resolution before connect, blocks internal/private IPs
-    http-get: func(url: string) -> tuple<string, string>;
+    /// headers: optional JSON object of extra headers, e.g. {"Authorization": "Bearer ...", "Accept": "application/json"}
+    http-get: func(url: string, headers: option<string>) -> tuple<string, string>;
 
-    /// HTTP POST request with body and content-type (blocking, with SSRF protection)
+    /// HTTP POST request with body, content-type, and optional headers (blocking, with SSRF protection)
     /// Returns (body, error) - error is empty string on success
-    http-post: func(url: string, body: string, content-type: string) -> tuple<string, string>;
+    /// headers: optional JSON object of extra headers, e.g. {"Authorization": "Bearer ..."}
+    http-post: func(url: string, body: string, content-type: string, headers: option<string>) -> tuple<string, string>;
 }
 
 world rpc-host {

--- a/worker/wit/world.wit
+++ b/worker/wit/world.wit
@@ -93,6 +93,17 @@ interface api {
 
     /// Raw JSON-RPC call (for any method not covered above)
     raw: func(method: string, params-json: string) -> tuple<string, string>;
+
+    // ==================== HTTP API ====================
+
+    /// HTTP GET request (blocking, with SSRF protection)
+    /// Returns (body, error) - error is empty string on success
+    /// Security: DNS resolution before connect, blocks internal/private IPs
+    http-get: func(url: string) -> tuple<string, string>;
+
+    /// HTTP POST request with body and content-type (blocking, with SSRF protection)
+    /// Returns (body, error) - error is empty string on success
+    http-post: func(url: string, body: string, content-type: string) -> tuple<string, string>;
 }
 
 world rpc-host {


### PR DESCRIPTION
reasoning currently the  host plaform allow native http call  with rpc  but is sync? 
we could have the samething but for general purpose http call 
 upside much less instructions for the caller
down side the wasm that is ran depend on outlayer vs being run exclusively in wasm (high count of instruction)


## Summary

Add blocking HTTP GET/POST to the existing `near:rpc/api` interface. ~240 WASM instructions per call vs ~10M for WASI P2 HTTP.

## Motivation

OutLayer supports arbitrary HTTP via WASI P2, but it costs ~10M instructions per call due to poll loops, chunked reads, and canonical ABI overhead. The existing `near:rpc` host functions use `reqwest::blocking::Client` and cost ~240 instructions. This adds the same blocking HTTP pattern for general-purpose fetching.

## Changes

| File | Change |
|------|--------|
| `worker/wit/world.wit` | +11 lines: `http-get`, `http-post` in `near:rpc/api` |
| `worker/src/outlayer_rpc/host_functions_sync.rs` | +102 lines: `http_get`, `http_post`, `validate_url` on RpcProxy + Host impls |
| `worker/src/executor/wasi_p2.rs` | 1 line: `fn` → `pub(crate) fn is_blocked_ip` |
| `worker/src/executor/mod.rs` | 1 line: `mod` → `pub(crate) mod wasi_p2` |

## Security

- **SSRF protection**: DNS resolution before connect, blocks all private/internal IPs (reuses `wasi_p2::is_blocked_ip` — CGNAT, RFC1918, link-local, ULA, multicast, loopback, etc.)
- **Response size cap**: 1 MB max (`MAX_HTTP_RESPONSE_BYTES`)
- **Scheme whitelist**: http/https only
- **Rate limiting**: shares existing RPC rate limit

## WIT Interface

```wit
http-get: func(url: string) -> tuple<string, string>;
http-post: func(url: string, body: string, content-type: string) -> tuple<string, string>;
```

Returns `(body, error)` — error is empty string on success.